### PR TITLE
Serve as HTML if the client supports it

### DIFF
--- a/app/templates/dump.html
+++ b/app/templates/dump.html
@@ -1,0 +1,14 @@
+<html>
+  <head>
+    <title></title>
+  </head>
+
+  <body>
+  <h1>{{ hostname }}</h1>
+
+  <pre>
+  {{ json_string }}
+  </pre>
+
+  </body>
+</html>

--- a/app/tests/endpoints/test_get_expiry.py
+++ b/app/tests/endpoints/test_get_expiry.py
@@ -3,7 +3,8 @@ import unittest
 
 import mock
 
-from nose.tools import assert_equal
+from nose.tools import assert_equal, assert_in
+
 from tornado.testing import AsyncHTTPTestCase
 from contextlib import contextmanager
 
@@ -41,6 +42,48 @@ class TestGetExpiry(AsyncHTTPTestCase):
         response = self.fetch('/example.com/', follow_redirects=False)
         assert_equal(301, response.code)
         assert_equal('/example.com', response.headers['location'])
+
+
+class TestGetExpiryContentTypeNegotiation(AsyncHTTPTestCase):
+    def get_app(self):
+        return main.make_app()
+
+    def _get_response_for_header(self, accept_header):
+        if accept_header is not None:
+            headers = {'Accept': accept_header}
+        else:
+            headers = {}
+
+        with setup_fake_response():
+            return self.fetch(
+                '/example.com',
+                follow_redirects=False,
+                headers=headers)
+
+    def test_no_accept_header_returns_json(self):
+        response = self._get_response_for_header(None)
+
+        assert_equal(200, response.code)
+        assert_equal(EXPECTED_JSON, json.loads(response.body.decode('utf-8')))
+        assert_equal('application/json', response.headers['content-type'])
+
+    def test_json_accept_header_returns_json(self):
+        response = self._get_response_for_header('application/json')
+
+        assert_equal(200, response.code)
+        assert_equal(EXPECTED_JSON, json.loads(response.body.decode('utf-8')))
+        assert_equal('application/json', response.headers['content-type'])
+
+    def test_html_accept_header_returns_json(self):
+        response = self._get_response_for_header(
+            '"text/html,application/xhtml+xml,application/xml;'
+            'q=0.9,*/*;q=0.8"')
+
+        assert_equal(200, response.code)
+        assert_in('<h1>example.com</h1>', response.body.decode('utf-8'))
+        assert_equal(
+            'text/html; charset=UTF-8',
+            response.headers['content-type'])
 
 
 class TestGetCertificateInfo(unittest.TestCase):


### PR DESCRIPTION
Examine the `Accept` header for `text/html` and return an HTML version of the
page if present.

Fixes #10
