### PR TITLE
Add sub endpoints for certificate components

### DIFF
--- a/app/format_response.py
+++ b/app/format_response.py
@@ -31,10 +31,6 @@ def format_response(hostname, port, x509):
         #  ('certificate.der', get_certificate_asn1_as_utf8(x509)),
     ])
 
-    command_line_examples = [
-        (name.replace('_', '-'), value) for name, value in FIELDS.items()
-    ]
-
     json_version = FIELDS
 
     return OrderedDict([
@@ -44,8 +40,6 @@ def format_response(hostname, port, x509):
         ])),
 
         ('cert', FIELDS),
-
-        ('command_line_examples', command_line_examples),
 
         ('json_version', json.dumps(json_version, indent=4)),
     ])

--- a/app/main.py
+++ b/app/main.py
@@ -53,7 +53,10 @@ class CertExpiryHandler(tornado.web.RequestHandler, RenderToTemplateMixin):
         self._render(response_data)
 
     def _render(self, response_data):
-        response_data['uri'] = self.request.host + self.request.uri
+        response_data['uri'] = '{}://{}{}'.format(
+            self.request.protocol,
+            self.request.host,
+            self.request.uri)
 
         if client_accepts_html(self.request.headers.get('Accept')):
 

--- a/app/templates/dump.html
+++ b/app/templates/dump.html
@@ -16,6 +16,10 @@ table, th, td {
   border: 1px solid black;
 }
 
+td {
+  padding: 10px;
+}
+
 td.arrow {
   border-right: none;
   border-left: none;
@@ -25,10 +29,15 @@ table.cli {
   font-family: monospace;
 }
 
-pre.clipped {
+pre.clipped-horizontal {
+  max-width: 200px;
+  overflow: hidden;
+  text-overflow: clip;
+}
+
+pre.clipped-vertical {
   max-height: 100px;
   overflow: hidden;
-  max-width: 200px;
   text-overflow: clip;
 }
 
@@ -42,38 +51,39 @@ pre.clipped {
   <table>
     <tbody>
       <tr>
-        <td>Serial number</td><td>{{ cert.serial_number }}</td>
+        <td><a href="{{ uri }}/serial-number">Serial number</a></td>
+        <td>{{ cert.serial_number }}</td>
       </tr>
 
       <tr>
-        <td>Expiry</td><td>{{ cert.expiry_datetime }}<!-- ({{ cert.expiry_days_remaining }} days time)--></td>
-      </tr>
-
-      <!--
-      <tr>
-        <td>
-          PEM file
-        </td>
-        <td>
-          <a href="certificate.txt">certificate.pem</a>
-        </td>
+        <td><a href="{{ uri }}/expiry-datetime">Expiry</a></td>
+        <td>{{ cert.expiry_datetime }}<!-- ({{ cert.expiry_days_remaining }} days time)--></td>
       </tr>
 
       <tr>
         <td>
-          ASN1 file
+          <a href="{{ uri }}/certificate.txt">certificate.txt</a>
         </td>
         <td>
-          <a href="certificate.der">certificate.der</a>
+          <pre class="clipped-vertical">{{ cert['certificate.txt'] }}</pre>
         </td>
       </tr>
 
       <tr>
         <td>
-          Text file
+          <a href="{{ uri }}/certificate.der">certificate.der</a><br>(ASN1 format)
         </td>
         <td>
-          <a href="certificate.txt">certificate.txt</a>
+          <pre class="clipped-vertical">{{ cert['certificate.der.txt'] }}</pre>
+        </td>
+      </tr>
+
+      <tr>
+        <td>
+          <a href="{{ uri }}/certificate.pem">certificate.pem</a><br>(PEM format)
+        </td>
+        <td>
+          <pre class="clipped-vertical">{{ cert['certificate.pem'] }}</pre>
         </td>
       </tr>
       </tr>

--- a/app/templates/dump.html
+++ b/app/templates/dump.html
@@ -39,8 +39,6 @@ pre.clipped {
   <body>
   <h1>SSL/TLS certificate for {{ request.hostname }}{% if request.port != 443 %}:{{ request.port }}{% endif %}</h1>
 
-  <h2>Certificate information</h2>
-
   <table>
     <tbody>
       <tr>
@@ -78,28 +76,7 @@ pre.clipped {
           <a href="certificate.txt">certificate.txt</a>
         </td>
       </tr>
-      -->
-    </tbody>
-  </table>
-
-  <h2>Command-line interface</h2>
-  <table class="cli">
-    <tbody>
-
-      <tr>
-        <td>$ curl {{ uri }}</td>
-        <td class="arrow">⇒</td>
-        <td><pre class="clipped">{{ json_version }}</pre></td>
       </tr>
-
-      {% for endpoint, example_value in command_line_examples %}
-      <tr>
-        <td>$ curl {{ uri }}/{{ endpoint }}</td>
-        <td class="arrow">⇒</td>
-        <td><pre class="clipped">{{ example_value }}</pre></td>
-      </tr>
-      {% endfor %}
-
     </tbody>
   </table>
 

--- a/app/tests/endpoints/test_get_expiry.py
+++ b/app/tests/endpoints/test_get_expiry.py
@@ -51,6 +51,55 @@ class TestGetExpiry(AsyncHTTPTestCase):
         assert_equal(301, response.code)
         assert_equal('/example.com', response.headers['location'])
 
+    def test_get_serial_number(self):
+        with setup_fake_response():
+            response = self.fetch('/example.com/serial-number')
+
+        assert_equal(200, response.code)
+        assert_equal('text/plain', response.headers['content-type'])
+        assert_equal('0e:64:c5:fb:c2:36:ad:e1:4b:17:2a:eb:41:c7:8c:b0',
+                     response.body.decode('utf-8'))
+
+    def test_get_expiry_datetime(self):
+        with setup_fake_response():
+            response = self.fetch('/example.com/expiry-datetime')
+
+        assert_equal(200, response.code)
+        assert_equal('text/plain', response.headers['content-type'])
+        assert_equal('2018-11-28T12:00:00Z',
+                     response.body.decode('utf-8'))
+
+    def test_get_certificate_text(self):
+        with setup_fake_response():
+            response = self.fetch('/example.com/certificate.txt')
+
+        assert_equal(200, response.code)
+        assert_equal('text/plain', response.headers['content-type'])
+        assert_equal('attachment;filename="certificate_example.com.txt"',
+                     response.headers['content-disposition'])
+        assert_equal(4223, len(response.body))
+
+    def test_get_certificate_txt(self):
+        with setup_fake_response():
+            response = self.fetch('/example.com/certificate.pem')
+
+        assert_equal(200, response.code)
+        assert_equal('text/plain', response.headers['content-type'])
+        assert_equal('attachment;filename="certificate_example.com.pem"',
+                     response.headers['content-disposition'])
+        assert_equal(2122, len(response.body))
+
+    def test_get_certificate_asn1(self):
+        with setup_fake_response():
+            response = self.fetch('/example.com/certificate.der')
+
+        assert_equal(200, response.code)
+        assert_equal('application/octet-stream',
+                     response.headers['content-type'])
+        assert_equal('attachment;filename="certificate_example.com.der"',
+                     response.headers['content-disposition'])
+        assert_equal(1526, len(response.body))
+
 
 class TestGetExpiryContentTypeNegotiation(AsyncHTTPTestCase):
     def get_app(self):

--- a/app/tests/test_format_response.py
+++ b/app/tests/test_format_response.py
@@ -40,13 +40,3 @@ def test_has_json_version_section():
             'expiry_datetime',
         ]),
         set(json.loads(RESULT['json_version']).keys()))
-
-
-def test_has_command_line_examples_section():
-    assert_in('command_line_examples', RESULT)
-    assert_equal(
-        set([
-            'serial-number',
-            'expiry-datetime',
-        ]),
-        set([key for key, value in RESULT['command_line_examples']]))

--- a/app/tests/test_format_response.py
+++ b/app/tests/test_format_response.py
@@ -24,6 +24,10 @@ def test_has_cert_section():
         set([
             'serial_number',
             'expiry_datetime',
+            'certificate.der',
+            'certificate.der.txt',
+            'certificate.txt',
+            'certificate.pem',
         ]),
         set(RESULT['cert'].keys()))
 


### PR DESCRIPTION
- Allow downloading certificate as PEM, DER (ASN1) and text format.
- Allow accessing expiry-datetime and serial-number directly
