### PR TITLE
Allow supervisor to kill the process

### DIFF
--- a/script/run.sh
+++ b/script/run.sh
@@ -17,7 +17,7 @@ activate_virtualenv() {
 }
 
 run_webapp() {
-    ${THIS_DIR}/../app/main.py
+    exec ${THIS_DIR}/../app/main.py
 }
 
 


### PR DESCRIPTION
Use `exec` in the run script to kick off python, otherwise supervisor can only
kill the wrapper script.

See http://stackoverflow.com/a/27058309

Related to #31
